### PR TITLE
Fixed Dynamic Copyright Year

### DIFF
--- a/index.html
+++ b/index.html
@@ -237,7 +237,7 @@
             <div class="row">
                 <div class="col-sm-5 copyright">
                     <p>
-                        Copyright &copy; 2020 YOUR NAME
+                        Copyright &copy; <span id="current-year">2022</span> YOUR NAME
                     </p>
                 </div>
                 <div class="col-sm-2 top">

--- a/js/scripts.js
+++ b/js/scripts.js
@@ -12,6 +12,9 @@
 
 (function($) {
 
+    // Show current year
+    $("#current-year").text(new Date().getFullYear());
+
     // Remove no-js class
     $('html').removeClass('no-js');
 


### PR DESCRIPTION
Fixed the footer copyright year to change dynamically every year. When the website loads footer copyright year will be updated to the current year.

Fixes #117 

#### Screenshot
![image](https://user-images.githubusercontent.com/74750414/147852723-84b973a9-0b78-448c-9fc7-b9caa98880f1.png)
